### PR TITLE
Pipeline recreation logic in case it exists and graceful handling of non-existing pipeline on read

### DIFF
--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -2,18 +2,52 @@ package api
 
 import (
 	"fmt"
-	"net/http"
-
 	"github.com/mitchellh/mapstructure"
 	gate "github.com/spinnaker/spin/cmd/gateclient"
+	"log"
+	"net/http"
+	"strings"
 )
 
-func CreatePipeline(client *gate.GatewayClient, pipeline interface{}) error {
+type PipelineConfig struct {
+	ID                   string                   `json:"id,omitempty"`
+	Type                 string                   `json:"type,omitempty"`
+	Name                 string                   `json:"name"`
+	Application          string                   `json:"application"`
+	Description          string                   `json:"description,omitempty"`
+	ExecutionEngine      string                   `json:"executionEngine,omitempty"`
+	Parallel             bool                     `json:"parallel"`
+	LimitConcurrent      bool                     `json:"limitConcurrent"`
+	KeepWaitingPipelines bool                     `json:"keepWaitingPipelines"`
+	Stages               []map[string]interface{} `json:"stages,omitempty"`
+	Triggers             []map[string]interface{} `json:"triggers,omitempty"`
+	ExpectedArtifacts    []map[string]interface{} `json:"expectedArtifacts,omitempty"`
+	Parameters           []map[string]interface{} `json:"parameterConfig,omitempty"`
+	Notifications        []map[string]interface{} `json:"notifications,omitempty"`
+	LastModifiedBy       string                   `json:"lastModifiedBy"`
+	Config               interface{}              `json:"config,omitempty"`
+	UpdateTs             string                   `json:"updateTs"`
+}
+
+func CreatePipeline(client *gate.GatewayClient, pipeline PipelineConfig) error {
 	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
 		resp, err := client.PipelineControllerApi.SavePipelineUsingPOST(client.Context, pipeline)
 
 		return nil, resp, err
 	})
+
+	if ErrorIndicatesPipelineAlreadyExists(err) {
+
+		log.Printf("Pipeline %v for application %v already existed. Deleting and recreating...", pipeline.Name, pipeline.Application)
+		if err = DeletePipeline(client, pipeline.Application, pipeline.Name); err != nil {
+			return fmt.Errorf("error deleting pipeline %v for application %v when trying a recreate. Error: %v", pipeline.Name, pipeline.Application, err.Error())
+		}
+		if err = CreatePipeline(client, pipeline); err != nil {
+			return fmt.Errorf("error recreating pipeline %v for application %v. Error: %v", pipeline.Name, pipeline.Application, err.Error())
+		}
+
+		return nil
+	}
 
 	if err != nil {
 		return err
@@ -24,6 +58,10 @@ func CreatePipeline(client *gate.GatewayClient, pipeline interface{}) error {
 	}
 
 	return nil
+}
+
+func ErrorIndicatesPipelineAlreadyExists(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "A pipeline with name") && strings.Contains(err.Error(), "already exists")
 }
 
 func GetPipeline(client *gate.GatewayClient, applicationName, pipelineName string, dest interface{}) (map[string]interface{}, error) {
@@ -39,7 +77,7 @@ func GetPipeline(client *gate.GatewayClient, applicationName, pipelineName strin
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return jsonMap, fmt.Errorf("%s", ErrCodeNoSuchEntityException)
 		}
-		return jsonMap, fmt.Errorf("Encountered an error getting pipeline %s, %s\n",
+		return jsonMap, fmt.Errorf("Encountered an error getting pipeline %s. Error: %s\n",
 			pipelineName,
 			err.Error())
 	}
@@ -95,6 +133,6 @@ func DeletePipeline(client *gate.GatewayClient, applicationName, pipelineName st
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Encountered an error deleting pipeline, status code: %d\n", resp.StatusCode)
 	}
-
+	log.Printf("deleted pipeline %v for application %v", pipelineName, applicationName)
 	return nil
 }

--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -37,7 +37,6 @@ func CreatePipeline(client *gate.GatewayClient, pipeline PipelineConfig) error {
 	})
 
 	if ErrorIndicatesPipelineAlreadyExists(err) {
-
 		log.Printf("Pipeline %v for application %v already existed. Deleting and recreating...", pipeline.Name, pipeline.Application)
 		if err = DeletePipeline(client, pipeline.Application, pipeline.Name); err != nil {
 			return fmt.Errorf("error deleting pipeline %v for application %v when trying a recreate. Error: %v", pipeline.Name, pipeline.Application, err.Error())

--- a/spinnaker/resource_pipeline.go
+++ b/spinnaker/resource_pipeline.go
@@ -147,7 +147,7 @@ func resourcePipelineExists(data *schema.ResourceData, meta interface{}) (bool, 
 	pipelineName := data.Get("name").(string)
 
 	var p pipelineRead
-	if jsonMap, err := api.GetPipeline(client, applicationName, pipelineName, &p); err != nil && len(jsonMap) > 0 {
+	if _, err := api.GetPipeline(client, applicationName, pipelineName, &p); err != nil && !strings.Contains(err.Error(), "EOF") {
 		return false, err
 	}
 

--- a/spinnaker/resource_pipeline.go
+++ b/spinnaker/resource_pipeline.go
@@ -53,14 +53,14 @@ func resourcePipelineCreate(data *schema.ResourceData, meta interface{}) error {
 	pipelineName := data.Get("name").(string)
 	pipeline := data.Get("pipeline").(string)
 
-	var tmp map[string]interface{}
+	var tmp api.PipelineConfig
 	if err := json.NewDecoder(strings.NewReader(pipeline)).Decode(&tmp); err != nil {
 		return err
 	}
 
-	tmp["application"] = applicationName
-	tmp["name"] = pipelineName
-	delete(tmp, "id")
+	tmp.Application = applicationName
+	tmp.Name = pipelineName
+	//delete(tmp, "id")
 
 	if err := api.CreatePipeline(client, tmp); err != nil {
 		return err
@@ -147,7 +147,7 @@ func resourcePipelineExists(data *schema.ResourceData, meta interface{}) (bool, 
 	pipelineName := data.Get("name").(string)
 
 	var p pipelineRead
-	if _, err := api.GetPipeline(client, applicationName, pipelineName, &p); err != nil {
+	if jsonMap, err := api.GetPipeline(client, applicationName, pipelineName, &p); err != nil && len(jsonMap) > 0 {
 		return false, err
 	}
 

--- a/spinnaker/resource_pipeline_template_config.go
+++ b/spinnaker/resource_pipeline_template_config.go
@@ -4,32 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
-
 	"github.com/armory-io/terraform-provider-spinnaker/spinnaker/api"
 	"github.com/ghodss/yaml"
 	"github.com/hashicorp/terraform/helper/schema"
+	"log"
 )
-
-type PipelineConfig struct {
-	ID                   string                   `json:"id,omitempty"`
-	Type                 string                   `json:"type,omitempty"`
-	Name                 string                   `json:"name"`
-	Application          string                   `json:"application"`
-	Description          string                   `json:"description,omitempty"`
-	ExecutionEngine      string                   `json:"executionEngine,omitempty"`
-	Parallel             bool                     `json:"parallel"`
-	LimitConcurrent      bool                     `json:"limitConcurrent"`
-	KeepWaitingPipelines bool                     `json:"keepWaitingPipelines"`
-	Stages               []map[string]interface{} `json:"stages,omitempty"`
-	Triggers             []map[string]interface{} `json:"triggers,omitempty"`
-	ExpectedArtifacts    []map[string]interface{} `json:"expectedArtifacts,omitempty"`
-	Parameters           []map[string]interface{} `json:"parameterConfig,omitempty"`
-	Notifications        []map[string]interface{} `json:"notifications,omitempty"`
-	LastModifiedBy       string                   `json:"lastModifiedBy"`
-	Config               interface{}              `json:"config,omitempty"`
-	UpdateTs             string                   `json:"updateTs"`
-}
 
 func resourcePipelineTemplateConfig() *schema.Resource {
 	return &schema.Resource{
@@ -98,7 +77,7 @@ func resourcePipelineTemplateConfigRead(data *schema.ResourceData, meta interfac
 	application := data.Get("application").(string)
 	name := data.Get("name").(string)
 
-	p := PipelineConfig{}
+	p := api.PipelineConfig{}
 	if _, err := api.GetPipeline(client, application, name, &p); err != nil {
 		if err.Error() == api.ErrCodeNoSuchEntityException {
 			data.SetId("")
@@ -174,7 +153,7 @@ func resourcePipelineTemplateConfigExists(data *schema.ResourceData, meta interf
 	return false, nil
 }
 
-func buildConfig(data *schema.ResourceData) (*PipelineConfig, error) {
+func buildConfig(data *schema.ResourceData) (*api.PipelineConfig, error) {
 	config := data.Get("pipeline_config").(string)
 
 	d, err := yaml.YAMLToJSON([]byte(config))
@@ -203,7 +182,7 @@ func buildConfig(data *schema.ResourceData) (*PipelineConfig, error) {
 		return nil, fmt.Errorf("application not set in pipeline configuration")
 	}
 
-	pConfig := &PipelineConfig{
+	pConfig := &api.PipelineConfig{
 		Name:                 name,
 		Application:          application,
 		Type:                 "templatedPipeline",


### PR DESCRIPTION
- added logic for the case that a pipeline that is to be created already exists: Delete and create the pipeline again.
- moved PipelineConfig to the api module as it is needed in pipeline.go then
- some more logging