### PR TITLE
recreate pipelines on certain errors

### DIFF
--- a/spinnaker/api/errors/errors.go
+++ b/spinnaker/api/errors/errors.go
@@ -1,0 +1,17 @@
+package errors
+
+import "regexp"
+
+var (
+	pipelineAlreadyExistsRegexp = regexp.MustCompile(`.*A pipeline with name .* already exists.*`)
+)
+
+// IsPipelineAlreadyExists returns true if the error indicates that a pipeline
+// already exists.
+func IsPipelineAlreadyExists(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return pipelineAlreadyExistsRegexp.MatchString(err.Error())
+}

--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-)
-import (
+
 	"github.com/mitchellh/mapstructure"
 	gate "github.com/spinnaker/spin/cmd/gateclient"
 )
@@ -99,4 +98,16 @@ func DeletePipeline(client *gate.GatewayClient, applicationName, pipelineName st
 	}
 	log.Printf("deleted pipeline %v for application %v", pipelineName, applicationName)
 	return nil
+}
+
+// RecreatePipeline is a convenience function for deleting and subsequently
+// recreating a pipeline. It will return an error if either of the delete and
+// create operations fails.
+func RecreatePipeline(client *gate.GatewayClient, applicationName, pipelineName string, pipeline interface{}) error {
+	err := DeletePipeline(client, applicationName, pipelineName)
+	if err != nil {
+		return err
+	}
+
+	return CreatePipeline(client, pipeline)
 }


### PR DESCRIPTION
This will recreate pipelines when the spinnaker API returns the
following error on pipeline creation or update operations:

    A pipeline with name <pipeline-name> already exists

We handle this by just recreating the problematic pipelines because
there is no other feasible way how to resolve this issue. The issue is
especially annoying because we also sometime see this error on update
operations where it is expected that the pipeline exists.