### PR TITLE
fix: lazily initialize gate API client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+VERSION         = 0.0.3
+LOCAL_PROVIDERS ="$$HOME/.terraform.d/plugins_local"
+BINARY_PATH     = "registry.terraform.io/Bonial-International-GmbH/spinnaker/${VERSION}/$$(go env GOOS)_$$(go env GOARCH)/terraform-provider-spinnaker_${VERSION}"
+
+# Builds the provider and adds it to an independently configured filesystem_mirror folder.
+#
+# For this to work your local ~/.terraformrc has to include the following:
+#
+# provider_installation {
+#   filesystem_mirror {
+#     path    = "<your-home-directory>/.terraform.d/plugins_local/"
+#     include = ["registry.terraform.io/Bonial-International-GmbH/spinnaker"]
+#   }
+#
+#   direct {
+#     exclude = ["registry.terraform.io/Bonial-International-GmbH/spinnaker"]
+#   }
+# }
+#
+.PHONY: build_local
+build_local:
+	@echo "Please configure your .terraformrc file to contain a filesystem_mirror block pointed at '${LOCAL_PROVIDERS}' for 'registry.terraform.io/Bonial-International-GmbH/spinnaker'"
+	@echo "You MUST use a direct exclusion in this block in order to pick up the built binary. Otherwise it will query the registry and find a distribution version"
+	@echo "You MUST comment out the 'version' constraint in the required_providers block in any Terraform installation you test this in."
+	@echo "You MUST delete existing cached plugins from any .terraform directories in Terraform installations you want to test against so that it will perform a lookup on the local mirror"
+	go build -o "${LOCAL_PROVIDERS}/${BINARY_PATH}"

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -54,8 +54,13 @@ func resourceApplicationCreate(data *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceApplicationRead(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	applicationName := data.Get("application").(string)
 	var app applicationRead
 	if err := api.GetApplication(client, applicationName, &app); err != nil {
@@ -70,16 +75,26 @@ func resourceApplicationUpdate(data *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceApplicationDelete(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	applicationName := data.Get("application").(string)
 
 	return api.DeleteAppliation(client, applicationName)
 }
 
 func resourceApplicationExists(data *schema.ResourceData, meta interface{}) (bool, error) {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return false, err
+	}
+
 	applicationName := data.Get("application").(string)
 
 	var app applicationRead
@@ -99,8 +114,12 @@ func resourceApplicationExists(data *schema.ResourceData, meta interface{}) (boo
 }
 
 func upsertApplication(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
 
 	if err := api.CreateApplication(client, data); err != nil {
 		return err

--- a/spinnaker/resource_pipeline.go
+++ b/spinnaker/resource_pipeline.go
@@ -48,15 +48,20 @@ type pipelineRead struct {
 }
 
 func resourcePipelineCreate(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	applicationName := data.Get("application").(string)
 	pipelineName := data.Get("name").(string)
 	rawPipeline := []byte(data.Get("pipeline").(string))
 
 	var pipeline map[string]interface{}
 
-	err := json.Unmarshal(rawPipeline, &pipeline)
+	err = json.Unmarshal(rawPipeline, &pipeline)
 	if err != nil {
 		return err
 	}
@@ -78,8 +83,13 @@ func resourcePipelineCreate(data *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePipelineRead(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	applicationName := data.Get("application").(string)
 	pipelineName := data.Get("name").(string)
 
@@ -108,8 +118,13 @@ func resourcePipelineRead(data *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePipelineUpdate(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	applicationName := data.Get("application").(string)
 	pipelineName := data.Get("name").(string)
 	rawPipeline := []byte(data.Get("pipeline").(string))
@@ -121,7 +136,7 @@ func resourcePipelineUpdate(data *schema.ResourceData, meta interface{}) error {
 
 	var pipeline map[string]interface{}
 
-	err := json.Unmarshal(rawPipeline, &pipeline)
+	err = json.Unmarshal(rawPipeline, &pipeline)
 	if err != nil {
 		return fmt.Errorf("could not unmarshal pipeline")
 	}
@@ -145,8 +160,13 @@ func resourcePipelineUpdate(data *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePipelineDelete(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	applicationName := data.Get("application").(string)
 	pipelineName := data.Get("name").(string)
 
@@ -158,8 +178,13 @@ func resourcePipelineDelete(data *schema.ResourceData, meta interface{}) error {
 }
 
 func resourcePipelineExists(data *schema.ResourceData, meta interface{}) (bool, error) {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return false, err
+	}
+
 	applicationName := data.Get("application").(string)
 	pipelineName := data.Get("name").(string)
 
@@ -193,7 +218,6 @@ func pipelineDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
 }
 
 func decodeEditAndEncodePipeline(pipeline string) (encodedPipeline string, err error) {
-
 	// Decode the pipeline into a map we can edit
 	pipelineBytes := []byte(pipeline)
 	var pipelineMapGeneric interface{}

--- a/spinnaker/resource_pipeline_template.go
+++ b/spinnaker/resource_pipeline_template.go
@@ -38,8 +38,13 @@ type templateRead struct {
 }
 
 func resourcePipelineTemplateCreate(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	var templateName string
 	template := data.Get("template").(string)
 
@@ -71,8 +76,13 @@ func resourcePipelineTemplateCreate(data *schema.ResourceData, meta interface{})
 }
 
 func resourcePipelineTemplateRead(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	templateName := data.Id()
 
 	t := make(map[string]interface{})
@@ -106,8 +116,13 @@ func resourcePipelineTemplateRead(data *schema.ResourceData, meta interface{}) e
 }
 
 func resourcePipelineTemplateUpdate(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	var templateName string
 	template := data.Get("template").(string)
 
@@ -136,8 +151,13 @@ func resourcePipelineTemplateUpdate(data *schema.ResourceData, meta interface{})
 }
 
 func resourcePipelineTemplateDelete(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	templateName := data.Id()
 
 	if err := api.DeletePipelineTemplate(client, templateName); err != nil {
@@ -149,8 +169,13 @@ func resourcePipelineTemplateDelete(data *schema.ResourceData, meta interface{})
 }
 
 func resourcePipelineTemplateExists(data *schema.ResourceData, meta interface{}) (bool, error) {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return false, err
+	}
+
 	templateName := data.Id()
 
 	t := &templateRead{}

--- a/spinnaker/resource_pipeline_template_config.go
+++ b/spinnaker/resource_pipeline_template_config.go
@@ -73,8 +73,12 @@ func resourcePipelineTemplateConfig() *schema.Resource {
 }
 
 func resourcePipelineTemplateConfigCreate(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
 
 	pConfig, err := buildConfig(data)
 	if err != nil {
@@ -93,8 +97,13 @@ func resourcePipelineTemplateConfigCreate(data *schema.ResourceData, meta interf
 }
 
 func resourcePipelineTemplateConfigRead(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	application := data.Get("application").(string)
 	name := data.Get("name").(string)
 
@@ -123,8 +132,13 @@ func resourcePipelineTemplateConfigRead(data *schema.ResourceData, meta interfac
 }
 
 func resourcePipelineTemplateConfigUpdate(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	pipelineID := data.Id()
 
 	pConfig, err := buildConfig(data)
@@ -141,8 +155,13 @@ func resourcePipelineTemplateConfigUpdate(data *schema.ResourceData, meta interf
 }
 
 func resourcePipelineTemplateConfigDelete(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return err
+	}
+
 	application := data.Get("application").(string)
 	name := data.Get("name").(string)
 
@@ -155,8 +174,13 @@ func resourcePipelineTemplateConfigDelete(data *schema.ResourceData, meta interf
 }
 
 func resourcePipelineTemplateConfigExists(data *schema.ResourceData, meta interface{}) (bool, error) {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
+	clientConfig := meta.(*clientConfig)
+
+	client, err := clientConfig.Client()
+	if err != nil {
+		return false, err
+	}
+
 	templateName := data.Id()
 
 	var t templateRead


### PR DESCRIPTION
The initialization of the gate API client results in an immediate API
call to the `/version` endpoint. This makes it impossible to use the
provider inside a module that will create the spinnaker as well
because the presence of the `provider "spinnaker" {}` block alone will
result in an API call to a non-existent endpoint.

This change delays the initialization of the gate API client until it is
needed. That allows the creation of the spinnaker and resources managed
by the spinnaker provider inside the same module by leveraging
`depends_on`.

The change also adds a `Makefile` to build and install the provider for
local testing as this has become a pain starting with terraform 0.13.