### PR TITLE
fix: improve pipeline error handling

### DIFF
--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -1,10 +1,9 @@
 package api
 
 import (
-	"fmt"
-	"log"
 	"net/http"
 
+	"github.com/Bonial-International-GmbH/terraform-provider-spinnaker/spinnaker/api/errors"
 	"github.com/mitchellh/mapstructure"
 	gate "github.com/spinnaker/spin/cmd/gateclient"
 )
@@ -15,62 +14,38 @@ func CreatePipeline(client *gate.GatewayClient, pipeline interface{}) error {
 
 		return nil, resp, err
 	})
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Encountered an error saving pipeline, status code: %d\n", resp.StatusCode)
+	if err != nil || (resp.StatusCode != http.StatusOK) {
+		return errors.NewResponseError(resp, err)
 	}
 
 	return nil
 }
 
 func GetPipeline(client *gate.GatewayClient, applicationName, pipelineName string, dest interface{}) (map[string]interface{}, error) {
-	jsonMap, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+	payload, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
 		return client.ApplicationControllerApi.GetPipelineConfigUsingGET(
 			client.Context,
 			applicationName,
 			pipelineName,
 		)
 	})
-	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
-			return jsonMap, fmt.Errorf("%s", ErrCodeNoSuchEntityException)
-		}
-		return jsonMap, fmt.Errorf("Encountered an error getting pipeline %s. Error: %s\n",
-			pipelineName,
-			err.Error())
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, errors.NewResponseError(resp, err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return jsonMap, fmt.Errorf("Encountered an error getting pipeline in pipeline %s with name %s, status code: %d\n",
-			applicationName,
-			pipelineName,
-			resp.StatusCode)
+	if err := mapstructure.Decode(payload, dest); err != nil {
+		return nil, err
 	}
 
-	if jsonMap == nil {
-		return jsonMap, fmt.Errorf(ErrCodeNoSuchEntityException)
-	}
-
-	if err := mapstructure.Decode(jsonMap, dest); err != nil {
-		return jsonMap, err
-	}
-
-	return jsonMap, nil
+	return payload, nil
 }
 
 func UpdatePipeline(client *gate.GatewayClient, pipelineID string, pipeline interface{}) error {
 	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
 		return client.PipelineControllerApi.UpdatePipelineUsingPUT(client.Context, pipelineID, pipeline)
 	})
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Encountered an error saving pipeline, status code: %d\n", resp.StatusCode)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return errors.NewResponseError(resp, err)
 	}
 
 	return nil
@@ -85,14 +60,10 @@ func DeletePipeline(client *gate.GatewayClient, applicationName, pipelineName st
 		)
 		return nil, resp, err
 	})
-	if err != nil {
-		return err
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return errors.NewResponseError(resp, err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Encountered an error deleting pipeline, status code: %d\n", resp.StatusCode)
-	}
-	log.Printf("deleted pipeline %v for application %v", pipelineName, applicationName)
 	return nil
 }
 

--- a/spinnaker/resource_pipeline_template_v2.go
+++ b/spinnaker/resource_pipeline_template_v2.go
@@ -87,7 +87,10 @@ func resourcePipelineTemplateV2Read(data *schema.ResourceData, meta interface{})
 	templateID := data.Get("template_id").(string)
 
 	template, err := api.GetPipelineTemplateV2(client, templateID)
-	if err != nil {
+	if apierrors.IsNotFound(err) {
+		data.SetId("")
+		return nil
+	} else if err != nil {
 		return fmt.Errorf("failed to fetch pipeline template %q: %w", templateID, err)
 	}
 


### PR DESCRIPTION
This adjusts the pipelines API to make use of the `ResponseError`
implementation added in https://github.com/Bonial-International-GmbH/terraform-provider-spinnaker/pull/13.

Furthermore it fixes a bug where non-existent pipelines produce errors
although terraform should just recreate them.