### PR TITLE
feat(arch): Add arm64 build.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip


### PR DESCRIPTION
With the newly released Terraform Version 1.2.2 I got the
following error using a Mac M1:

Provider registry.terraform.io/bonial-international-gmbh/spinnaker v0.1.1 does
not have a package available for your current platform, darwin_arm64.

So this patch should fix it by adding an arm64 build.